### PR TITLE
kubernetes-secrets

### DIFF
--- a/base/README.md
+++ b/base/README.md
@@ -5,7 +5,7 @@ This folder provides the bare minimum configuration required to set up Jenkins w
 This configuration can be used to deploy Jenkins directly if you want, although the configured Jenkins instance is not especially useful without further plugins. By default this Jenkins instance is open, and requires no login credentials to access.
 
 ### Examples of usage
-An example of setting up basic authorization and an admin account can be found [here](../examples/admin-password).
+An example of setting up basic authorization and an admin account can be found [here](../examples/admin-password). This example also shows you how Kubernetes Secrets can be [read into Jenkins](../examples/admin-password/secrets.yaml) for use in builds.
 
 ### Installed plugins
 This configuration installs the following plugins:
@@ -23,3 +23,6 @@ This configuration does accept a number of optional environment variables, to co
 |------|-------------|---------|---------|
 | DONT_INSTALL_LOCAL_CLOUD | Skip configuration of a local Cloud. Defining this will prevent builds from running in the local cluster. | YES | |
 | LOCAL_CLOUD_NAME | Set the name of the local Cloud. This is useful if you require the local Cloud to be particularly named for further configuration | myCloud | kubernetes |
+
+## Permissions
+The base configuration sets up a number of permissions for the Jenkins instance, to allow it to perform builds in the local Kubernetes cluster, and read Secrets and ConfigMaps from within the same namespace that Jenkins runs in. Due to these permissions being set up, it is recommended to run Jenkins within it's own namespace, and not the `default` namespace.

--- a/base/configuration/plugins.txt
+++ b/base/configuration/plugins.txt
@@ -1,1 +1,2 @@
 kubernetes
+kubernetes-credentials-provider

--- a/base/role-bindings.yaml
+++ b/base/role-bindings.yaml
@@ -9,4 +9,29 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: jenkins-master
-    namespace: default
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jenkins-master-read-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-secrets
+subjects:
+  - kind: ServiceAccount
+    name: jenkins-master
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: jenkins-master-read-config-maps
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: read-config-maps
+subjects:
+  - kind: ServiceAccount
+    name: jenkins-master

--- a/base/roles.yaml
+++ b/base/roles.yaml
@@ -15,3 +15,23 @@ rules:
  - apiGroups: [""]
    resources: ["events"]
    verbs: ["watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-secrets
+rules:
+ - apiGroups: [""]
+   resources: ["secrets"]
+   verbs: ["get","list","watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: read-config-maps
+rules:
+ - apiGroups: [""]
+   resources: ["configmaps"]
+   verbs: ["get","list","watch"]

--- a/examples/admin-password/README.md
+++ b/examples/admin-password/README.md
@@ -4,9 +4,12 @@ This example deploys a very basic Jenkins instance, extending our [base configur
 To deploy and use this example, perform the following steps:
  * Create a new namespace for the example `kubectl create ns jenkins-on-k8s-admin-example`
  * Set an admin password file `echo JENKINS_ADMIN_PASSWORD=examplePassword > jenkins-admin-password.env`
- * Deploy Jenkins `kubectl apply -n jenkins-on-k8s-admin-example -k .`
+ * Deploy Jenkins `kubectl apply -k .`
  * Wait for the deployment to complete `kubectl rollout status deployment/jenkins-master -n jenkins-on-k8s-admin-example`
  * Port forward to Jenkins to see the UI `kubectl port-forward deployment/jenkins-master -n jenkins-on-k8s-admin-example 8080`
  * Visit the UI on [https://127.0.0.1:8080](https://127.0.0.1:8080) and confirm you can see Jenkins
  * Use the login link and login with username of `admin` and the password you set earlier
  * Confirm you can now see a manage jenkins link
+
+## Reading Kubernetes secrets
+This example also has a kubernetes Secret in it. This can be found [here](secrets.yaml). This Secret is readable by Jenkins (due to the annotations on it) and can be used in Jenkinsfiles or plugin configuration. For more information and examples, check out the [plugin documentation](https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/).

--- a/examples/admin-password/kustomization.yaml
+++ b/examples/admin-password/kustomization.yaml
@@ -4,6 +4,8 @@ bases:
   - ../../base
 patchesStrategicMerge:
   - deployments.yaml
+resources:
+  - secrets.yaml
 configMapGenerator:
   - name: jenkins-example-customization
     files:
@@ -12,3 +14,4 @@ configMapGenerator:
 secretGenerator:
   - name: jenkins-admin-password
     env: jenkins-admin-password.env
+namespace: jenkins-on-k8s-admin-example

--- a/examples/admin-password/secrets.yaml
+++ b/examples/admin-password/secrets.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+# this is the jenkins id
+  name: "test-username-pass"
+  labels:
+# so we know what type it is
+    "jenkins.io/credentials-type": "usernamePassword"
+  annotations:
+# description - can not be a label as spaces are not allowed
+    "jenkins.io/credentials-description" : "A username and password credential from Kubernetes"
+type: Opaque
+stringData:
+  username: myUsername
+  password: 'Pa$$word'


### PR DESCRIPTION
This change sets up Kubernetes Secret reading in the base configuration. This is done as it allows for a much nicer Secrets integration between Jenkins and Kubernetes in downstream configurations, without assuming an actual Secrets provider beyond "Kubernetes". How Secrets get into a Kubernetes namespace is left up to the user.