### PR TITLE
Save OrganizationFolder after configuring it

### DIFF
--- a/components/github-organization/configuration/groovy/github-organization.groovy
+++ b/components/github-organization/configuration/groovy/github-organization.groovy
@@ -25,6 +25,7 @@ if (orgName != null) {
     new ForkPullRequestDiscoveryTrait(1, new ForkPullRequestDiscoveryTrait.TrustPermission()),  // Allow people in the organisation to update Jenkinsfiles in forks
     ]
     folder.navigators.replace(navigator)
+    folder.save()
     Jenkins.instance.save()
     navigator.afterSave(folder)
 }


### PR DESCRIPTION
This PR forces the OrganizationFolder to save after it has been set up; this partially fixes #11 -- it is now possible to initiate an org scan by clicking on scan, and that works as expected. 

Without this, you currently must Edit the OrganizationFolder in the UI and hit 'Save', before it seems to persist the folder properly.

No scan is triggered as part of spinning up Jenkins still, but that is perhaps(?) working as intended; I haven't left the instance alone to see if it would've scanned on its own the next day, without me manually hitting scan the first time.